### PR TITLE
allow to ignore errors when updating objects fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- allow to ignore errors when updating resources fails
+
 ### Changed
 
 ## 1.2.2
 ### Changed
 - Use go 1.16
-- Update for Kubernetes 1.20 
+- Update for Kubernetes 1.20
 
 ## 1.1.0 - 2020-06-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -166,8 +166,14 @@ Usage:
   kubernetes-deployment-restart-controller [OPTIONS]
 
 Application Options:
-  -c, --restart-check-period= Time interval to check for pending restarts in milliseconds (default: 500) [$RESTART_CHECK_PERIOD]
-  -r, --restart-grace-period= Time interval to compact restarts in seconds (default: 5) [$RESTART_GRACE_PERIOD]
+  -c, --restart-check-period= Time interval to check for pending restarts in milliseconds
+                              (default: 500) [$RESTART_CHECK_PERIOD]
+  -r, --restart-grace-period= Time interval to compact restarts in seconds (default: 5)
+                              [$RESTART_GRACE_PERIOD]
+      --ignored-errors=       List of error patterns to just warn of, instead of exiting the controller.
+                              Useful if previously legal objects are not valid anymore but have not yet
+                              been updated, e.g. on admission control changes. ENV var splits on ;
+                              (semicolon). [$IGNORED_ERRORS]
   -v, --verbose=              Be verbose [$VERBOSE]
       --version               Print version information and exit
 

--- a/kubernetes-deployment-restart-controller.go
+++ b/kubernetes-deployment-restart-controller.go
@@ -15,10 +15,11 @@ import (
 )
 
 var options struct {
-	RestartCheckPeriod int  `short:"c" long:"restart-check-period" env:"RESTART_CHECK_PERIOD" description:"Time interval to check for pending restarts in milliseconds" default:"500"`
-	RestartGracePeriod int  `short:"r" long:"restart-grace-period" env:"RESTART_GRACE_PERIOD" description:"Time interval to compact restarts in seconds" default:"5"`
-	Verbose            int  `short:"v" long:"verbose" env:"VERBOSE" description:"Be verbose"`
-	Version            bool `long:"version" description:"Print version information and exit"`
+	RestartCheckPeriod int      `short:"c" long:"restart-check-period" env:"RESTART_CHECK_PERIOD" description:"Time interval to check for pending restarts in milliseconds" default:"500"`
+	RestartGracePeriod int      `short:"r" long:"restart-grace-period" env:"RESTART_GRACE_PERIOD" description:"Time interval to compact restarts in seconds" default:"5"`
+	IgnoredErrors      []string `long:"ignored-errors" env:"IGNORED_ERRORS" env-delim:";" description:"List of error patterns to just warn of, instead of exiting the controller. Useful if previously legal objects are not valid anymore but have not yet been updated, e.g. on admission control changes. ENV var splits on ; (semicolon)."`
+	Verbose            int      `short:"v" long:"verbose" env:"VERBOSE" description:"Be verbose"`
+	Version            bool     `long:"version" description:"Print version information and exit"`
 }
 
 // VERSION represents the current version of the release.
@@ -36,7 +37,7 @@ func main() {
 	addr := fmt.Sprintf("0.0.0.0:10254")
 	go func() { glog.Fatal(http.ListenAndServe(addr, nil)) }()
 
-	controller := controller.NewDeploymentConfigController(time.Duration(options.RestartCheckPeriod)*time.Millisecond, time.Duration(options.RestartGracePeriod)*time.Second)
+	controller := controller.NewDeploymentConfigController(time.Duration(options.RestartCheckPeriod)*time.Millisecond, time.Duration(options.RestartGracePeriod)*time.Second, options.IgnoredErrors)
 	util.InstallSignalHandler(controller.Stop)
 
 	err := controller.Run()

--- a/src/controller/controller.go
+++ b/src/controller/controller.go
@@ -26,12 +26,12 @@ type DeploymentConfigController struct {
 }
 
 // NewDeploymentConfigController creates a new instance of DeploymentConfigController
-func NewDeploymentConfigController(restartCheckPeriod time.Duration, restartGracePeriod time.Duration) *DeploymentConfigController {
+func NewDeploymentConfigController(restartCheckPeriod time.Duration, restartGracePeriod time.Duration, ignoredErrors []string) *DeploymentConfigController {
 	k8sClient := util.Clientset()
 	factory := informers.NewSharedInformerFactory(k8sClient, 5*time.Minute)
 
 	dcc := &DeploymentConfigController{
-		configAgent: NewConfigAgent(k8sClient, restartCheckPeriod, restartGracePeriod),
+		configAgent: NewConfigAgent(k8sClient, restartCheckPeriod, restartGracePeriod, ignoredErrors),
 		factory:     factory,
 		Stop:        make(chan struct{}),
 	}

--- a/src/controller/controller_test.go
+++ b/src/controller/controller_test.go
@@ -149,7 +149,7 @@ func TestDeletingUnknownResourceDoesNothing(t *testing.T) {
 }
 
 func controller() *DeploymentConfigController {
-	controller := NewDeploymentConfigController(100*time.Millisecond, 1*time.Second)
+	controller := NewDeploymentConfigController(100*time.Millisecond, 1*time.Second, []string{})
 	controller.configAgent = test.NewDummyConfigAgent()
 	return controller
 }


### PR DESCRIPTION
This is useful when previously legal objects are not legal anymore, without being updated. For example, as a result of an admission control change. Since a human is needed to bring the old object into conformance with the new requirements, the controller won't be able to restart these objects. In such a scenario, it should still be able to continue restarting other deployments until the affected one is fixed.